### PR TITLE
Adding save/clear functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,25 @@ function Preferences (id, defs, options) {
     } catch (err) {}
   }
 
+  function clear () {
+    for (var o in self) delete self[o]
+    save()
+  }
+
+  if (Object.defineProperty) {
+    Object.defineProperty(self, "save", {
+      enumerable: false,
+      writable: false,
+      value: save
+    });
+
+    Object.defineProperty(self, "clear", {
+      enumerable: false,
+      writable: false,
+      value: clear
+    });
+  }
+
   try {
     // Try to read and decode preferences saved on disc
     savedData = JSON.parse(decode(fs.readFileSync(filepath, 'utf8')))


### PR DESCRIPTION
This could be somewhat contentious as it potentially breaks prefs = {}. Though, with some simple testing, it does look like prefs = {} breaks the preference object anyway (which makes sense). So...in all likelihood, this probably just fixes/adds the ability to clear...